### PR TITLE
Fixing/changing MixSAM implementation

### DIFF
--- a/meanfield_optimizer.py
+++ b/meanfield_optimizer.py
@@ -1,4 +1,5 @@
 from abc import ABC, abstractmethod
+from copy import deepcopy
 import torch
 from torch.optim import Optimizer
 from torch.nn.init import constant_
@@ -13,7 +14,7 @@ class MeanFieldOptimizer(Optimizer, ABC):
     format as in param_groups. And the populate_gradients_for_Sigma
     method."""
 
-    def __init__(self, params, base_optimizer, lr_sigma = 0.01, sigma_prior = 1, init_scale_M = 0.1, kl_div_weight = 0.01, **kwargs):
+    def __init__(self, params, base_optimizer, lr_sigma = 0.01, sigma_prior = 10, init_scale_M = 0.1, kl_div_weight = 0.01, **kwargs):
        
         if not lr_sigma >= 0.0:
             raise ValueError(f"Invalid lr_sigma, should be non-negative: {lr_sigma}")
@@ -77,6 +78,7 @@ class MeanFieldOptimizer(Optimizer, ABC):
             for param in param_group["params"]:
                 if param.requires_grad:
                     param.data = self.state[param]["old_p"]
+                    param.grad.add_(2 * param.detach().clone() / self.sigma_prior**2)
 
     @torch.no_grad()
     @abstractmethod

--- a/meanfield_optimizer.py
+++ b/meanfield_optimizer.py
@@ -207,7 +207,7 @@ class MixSAM(MeanFieldOptimizer):
             for param in param_group['params']:
                 if param.requires_grad:
                     if param.grad is None:
-                        raise ValueError('VariationalSAM requires gradients to be populated to take a step.')
+                        raise ValueError('MixSAM requires gradients to be populated to take a step.')
                     perturbation = param.grad.detach().clone()
                     squared_norm.add_((perturbation**2).sum())
                     num_params+=torch.numel(perturbation)
@@ -225,7 +225,7 @@ class MixSAM(MeanFieldOptimizer):
             for perturbation in perturbation_group['params']:
                 if perturbation is not None:
                     perturbation.mul_(scale)
-                    perturbation.add_(self.kappa.scale * torch.randn_like(perturbation))
+                    perturbation.add_(self.kappa_scale * torch.randn_like(perturbation))
                     squared_norm.add_((perturbation**2).sum())
         
         scale = torch.sqrt(num_params / squared_norm)


### PR DESCRIPTION
I changed the implementation of MixSAM, with relevant changes to the base class MeanFieldOptimizer.

I have run some tests that show that the magnitude of the perturbations is as expected, that the behaviour of increasing kappa is as expected, and that MixSAM’s behaviour on a linear function is exactly the same as SGD with appropriately tuned weight decay parameters.

To reproduce SAM with specific rho and weight decay, set parameters as follows:
- init_scale_M - has to be set to rho/sqrt(k) where k is the number of learnable parameters
- kl_div_weight has to be 1/N where N is the total number of datapoints. However, only the ratio kl_div_weight/sigma_prior**2  matters here, which has to be the same as weight decay / 2 to match SAM with the same weight decay. sigma_prior is the standard deviation of the prior distribution, so that can be chosen to be something like 10
- the base_optimizer should not have weight decay enabled. MixSAM already applies weight decay by virtue of the KL penalty being an integral part of it.